### PR TITLE
Try debugging panic

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -17,10 +17,11 @@ func CreateBook() Book {
 	// message, which is needed to instantiate the Book struct.  You don't need to
 	// understand segments and roots yet (or maybe ever), but if you're curious, messages
 	// and segments are documented here:  https://capnproto.org/encoding.html
-	_, seg, err := capnp.NewMessage(arena)
+	msg, seg, err := capnp.NewMessage(arena)
 	if err != nil {
 		panic(err)
 	}
+	msg.ResetReadLimit(1 << 63)
 
 	// Create a new Book struct.  Every message must have a root struct.  Again, it is
 	// not important to understand "root structs" at this point.  For now, just understand
@@ -40,7 +41,10 @@ func CreateBook() Book {
 }
 
 func onerun(b *Book) bool {
-	bytes, _ := b.TitleBytes()
+	bytes, err := b.TitleBytes()
+	if err != nil {
+		panic(err)
+	}
 	return 100 < len(bytes)
 }
 


### PR DESCRIPTION
```
-> % go test -bench=.
goos: linux
goarch: amd64
pkg: github.com/pikrzysztof/capnp-benchmark
cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
BenchmarkAll/1_concurrency-8         	panic: capnp: read pointer: read traversal limit reached

goroutine 22 [running]:
github.com/pikrzysztof/capnp-benchmark.onerun(...)
	/home/kris/dev/org/chfagg-cpuusage/benchmark/main_test.go:46
github.com/pikrzysztof/capnp-benchmark.loop(0xd1d128, 0xc00009c840, 0xc0000e8480?)
	/home/kris/dev/org/chfagg-cpuusage/benchmark/main_test.go:53 +0xc5
created by github.com/pikrzysztof/capnp-benchmark.BenchmarkAll.func1
	/home/kris/dev/org/chfagg-cpuusage/benchmark/main_test.go:65 +0xc5
exit status 2
FAIL	github.com/pikrzysztof/capnp-benchmark	0.508s
-> % go test
PASS
ok  	github.com/pikrzysztof/capnp-benchmark	0.001s
```